### PR TITLE
feat(BusSearch): adjust input padding and remove unnecessary margin

### DIFF
--- a/Frontend/src/components/page/BusSearch.jsx
+++ b/Frontend/src/components/page/BusSearch.jsx
@@ -126,7 +126,7 @@ const PlaceSearch = ({ label, onSelect, enableUseMyLocation = false }) => {
         value={query}
         placeholder={t("busSearch.typePlaceholder")}
         onChange={(e) => handleSearch(e.target.value)}
-        className={`w-full p-4 border-2 rounded-xl focus:ring-4 transition-all ${
+        className={`w-full p-5 border-2 rounded-xl focus:ring-4 transition-all ${
           darktheme
             ? "bg-gray-900/50 border-gray-700 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500/20"
             : "bg-white border-gray-200 text-gray-900 focus:border-blue-500 focus:ring-blue-500/20"
@@ -415,7 +415,7 @@ const BusSearch = () => {
                   : "bg-gray-100 border border-gray-200"
               }`}
             >
-              <div className="flex flex-col sm:flex-row justify-center items-center gap-4 w-full mt-6">
+              <div className="flex flex-col sm:flex-row justify-center items-center gap-4 w-full">
                 <button
                   onClick={() => setSearchType("route")}
                   className={`px-6 py-3 rounded-xl transition-all duration-300 font-semibold flex items-center gap-2 ${


### PR DESCRIPTION
- Increase input padding from p-4 to p-5 in PlaceSearch component for improved spacing
- Remove mt-6 top margin from search type button container to eliminate excessive vertical spacing

## 📌 Description

Please include a clear and concise description of what this PR changes.

Fixes: # (issue number, if applicable)

---

## 🔧 Type of Change

Please mark the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)

<img width="1093" height="531" alt="image" src="https://github.com/user-attachments/assets/beeed8e8-a30d-4d0b-a961-28f78e028c87" />


---

## ✅ Checklist

Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes

Add any other context or information for reviewers.
